### PR TITLE
[windows] Always use system-shipped tar

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,15 +44,21 @@ runs:
         $TempDir = New-TemporaryFile | % { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
         $TarFile = Join-Path $TempDir "${{ inputs.name }}.tar"
         Write-Output "tar-file=$TarFile" >> $env:GITHUB_OUTPUT
+        if ($IsWindows) {
+          # Workaround issue where GNU tar from Git takes priority over Windows tar.
+          $Tar = "${env:WINDIR}\System32\tar.exe"
+        } else {
+          $Tar = "tar"
+        }
         if (Test-Path "${{ inputs.path }}" -PathType Leaf) {
           # Input is a single file.
           $Path = Split-Path "${{ inputs.path }}"
           if ($Path -eq "") {
             $Path = "."
           }
-          tar cf $TarFile -C $Path (Split-Path -Leaf "${{ inputs.path }}")
+          & $Tar cf $TarFile -C $Path (Split-Path -Leaf "${{ inputs.path }}")
         } else {
-          tar cf $TarFile -C "${{ inputs.path }}" .
+          & $Tar cf $TarFile -C "${{ inputs.path }}" .
         }
 
     - uses: actions/upload-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -44,12 +44,7 @@ runs:
         $TempDir = New-TemporaryFile | % { Remove-Item $_; New-Item -ItemType Directory -Path $_ }
         $TarFile = Join-Path $TempDir "${{ inputs.name }}.tar"
         Write-Output "tar-file=$TarFile" >> $env:GITHUB_OUTPUT
-        if ($IsWindows) {
-          # Workaround issue where GNU tar from Git takes priority over Windows tar.
-          $Tar = "${env:WINDIR}\System32\tar.exe"
-        } else {
-          $Tar = "tar"
-        }
+        $Tar = if ($IsWindows) { "${env:WINDIR}\System32\tar.exe" } else { "tar" }
         if (Test-Path "${{ inputs.path }}" -PathType Leaf) {
           # Input is a single file.
           $Path = Split-Path "${{ inputs.path }}"


### PR DESCRIPTION
On some Windows runners, it is possible for a GNU tar binary to be further ahead in `PATH`. In particular, Git for Windows ships with a GNU tar binary, which can't parse Windows-style paths properly. This works around the issue by always using the BSD tar binary that ships with the operating system on Windows.